### PR TITLE
Fix #22 and add BugReports metadata to DESCRIPTION

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -6,6 +6,7 @@ Date: 2015-07-13
 Author: Frederick Solt <frederick-solt@uiowa.edu>, Yue Hu <yue-hu-1@uiowa.edu>
 Maintainer: Yue Hu <yue-hu-1@uiowa.edu>
 Description: Quick and easy dot-and-whisker plots of regression models saved in tidy data frames.
+BugReports: https://github.com/fsolt/dotwhisker/issues
 Depends: R (>= 3.2.1), ggplot2,dplyr, gridExtra, gtable
 Imports:
     grid,

--- a/vignettes/dwplot-vignette.Rmd
+++ b/vignettes/dwplot-vignette.Rmd
@@ -5,7 +5,7 @@ date: "`r Sys.Date()`"
 output: rmarkdown::html_vignette
 bibliography: vignette_dwplot.bib
 vignette: >
-  %\VignetteIndexEntry{Vignette Title}
+  %\VignetteIndexEntry{dwplot: Dot-and-Whisker Plots of Regression Coefficients from Tidy Data Frames}
   %\VignetteEngine{knitr::rmarkdown}
   %\VignetteEncoding{ASCII}
 ---


### PR DESCRIPTION
This fixes bug #22 and adds a BugReports link to the DESCRIPTION file, making it easy for useRs downloading the package from CRAN to find the GitHub repository in the event that they have bug reports, fixes or enhancements.