### PR TITLE
omit only NAs in term column

### DIFF
--- a/R/dwplot.R
+++ b/R/dwplot.R
@@ -235,7 +235,8 @@ dw_tidy <- function(x, by_2sd, ...) {
                     mutate(model = mk_model(model))
             } else {
                 df <- purrr::map_dfr(x, .id = "model",
-                    ~broom::tidy(., conf.int = TRUE, ...)) %>%
+                          function(x) {
+                              broom::tidy(x, conf.int = TRUE, ...) }) %>%
                     mutate(model = if_else(!is.na(suppressWarnings(as.numeric(model))),
                                            paste("Model", model), model))
             }


### PR DESCRIPTION
`dwplot` does an `na.omit` step after matching order of term names. I assume that's done to eliminate terms that weren't matched in the specified order, but it has bad side effects for the new version of `broom.mixed`, which can include a `group` column in the tidied model that is `NA` for the fixed effects. This modification looks for NA values only in the `term` column ...